### PR TITLE
Screen::intersects result parameter as pointer instead of reference

### DIFF
--- a/src/Cinder-LeapSdk.cpp
+++ b/src/Cinder-LeapSdk.cpp
@@ -311,7 +311,7 @@ int32_t Screen::getWidth() const
 	return mScreen.widthPixels();
 }
 
-bool Screen::intersects( const Pointable& pointable, Vec3f& result, bool normalize,
+bool Screen::intersects( const Pointable& pointable, Vec3f* result, bool normalize,
 						float clampRatio ) const
 {
 	Leap::Vector v	= mScreen.intersect( pointable.mPointable, normalize, clampRatio );
@@ -320,7 +320,7 @@ bool Screen::intersects( const Pointable& pointable, Vec3f& result, bool normali
 		v.z != v.z ) { // NaN
 		return false;
 	}
-	result			= toVec3f( v );
+	*result			= toVec3f( v );
 	return true;
 }
 

--- a/src/Cinder-LeapSdk.h
+++ b/src/Cinder-LeapSdk.h
@@ -222,7 +222,7 @@ public:
 		the intersection to \a result. Set \a normalize to true for \a result to 
 		represent a percentage of screen size. Default is false. \a clampRatio 
 		adjusts the screen border. */
-	bool			intersects( const Pointable& pointable, ci::Vec3f& result,
+	bool			intersects( const Pointable& pointable, ci::Vec3f* result,
 							   bool normalize = false, float clampRatio = 1.0f ) const;
 private:
 	Leap::Screen	mScreen;


### PR DESCRIPTION
I believe this follows the cinder parameter passing conventions better. e.g. Camera::getBillboardVectors( Vec3f \* right, Vec3f \* up)    
