### PR TITLE
Adding Leap event signals so that any number of classes can connect and respond to signals such as onConnect and onDisconnect

### DIFF
--- a/src/Cinder-LeapSdk.cpp
+++ b/src/Cinder-LeapSdk.cpp
@@ -89,7 +89,7 @@ Vec3f toVec3f( const Leap::Vector& v )
 	return Vec3f( v.x, v.y, v.z );
 }
 	
-Leap::Vector toLeapVedctor( const Vec3f& v )
+Leap::Vector toLeapVector( const Vec3f& v )
 {
 	return Leap::Vector( v.x, v.y, v.z );
 }
@@ -109,30 +109,35 @@ void Listener::onConnect( const Leap::Controller& controller )
 {
 	lock_guard<mutex> lock( *mMutex );
 	mConnected = true;
+    mSignalLeapConnect();
 }
 
 void Listener::onDisconnect( const Leap::Controller& controller ) 
 {
 	lock_guard<mutex> lock( *mMutex );
 	mConnected = false;
+    mSignalLeapDisconnect();
 }
 	
 void Listener::onExit( const Leap::Controller& controller )
 {
 	lock_guard<mutex> lock( *mMutex );
 	mExited = true;
+    mSignalLeapExit();
 }
 
 void Listener::onFocusGained( const Leap::Controller& controller )
 {
 	lock_guard<mutex> lock( *mMutex );
 	mFocused = true;
+    mSignalLeapFocusGained();
 }
 
 void Listener::onFocusLost( const Leap::Controller& controller )
 {
 	lock_guard<mutex> lock( *mMutex );
 	mFocused = false;
+    mSignalLeapFocusLost();
 }
 	
 void Listener::onFrame( const Leap::Controller& controller ) 
@@ -148,6 +153,7 @@ void Listener::onInit( const Leap::Controller& controller )
 {
 	lock_guard<mutex> lock( *mMutex );
 	mInitialized = true;
+    mSignalLeapInit();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Cinder-LeapSdk.h
+++ b/src/Cinder-LeapSdk.h
@@ -59,6 +59,8 @@ ci::Vec3f		toVec3f( const Leap::Vector& v );
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 
+typedef	 ci::signals::signal<void()>    EventSignalLeap;
+
 //! Receives and manages Leap controller data.
 class Listener : public Leap::Listener
 {
@@ -71,7 +73,14 @@ protected:
 	virtual void	onFocusGained( const Leap::Controller& controller );
 	virtual void	onFocusLost( const Leap::Controller& controller );
 	virtual void	onInit( const Leap::Controller& controller );
-	
+
+    EventSignalLeap mSignalLeapConnect;
+    EventSignalLeap mSignalLeapDisconnect;
+    EventSignalLeap mSignalLeapExit;
+    EventSignalLeap mSignalLeapFocusGained;
+    EventSignalLeap mSignalLeapFocusLost;
+    EventSignalLeap mSignalLeapInit;
+
 	volatile bool	mConnected;
 	volatile bool	mExited;
 	volatile bool	mFocused;
@@ -101,6 +110,19 @@ public:
 	
 	//! Returns LEAP controller associated with this device's listener.
 	Leap::Controller*	getController() const;
+    
+    //! Returns onConnect signal for use in connecting user defined callbacks
+    EventSignalLeap&     getSignalLeapConnect() { return mListener.mSignalLeapConnect; }
+    //! Returns onDisconnect signal for use in connecting user defined callbacks
+    EventSignalLeap&     getSignalLeapDisconnect() { return mListener.mSignalLeapDisconnect; }
+    //! Returns onExit signal for use in connecting user defined callbacks
+    EventSignalLeap&     getSignalLeapExit() { return mListener.mSignalLeapExit; }
+    //! Returns onFocusGained signal for use in connecting user defined callbacks
+    EventSignalLeap&     getSignalLeapFocusGained() { return mListener.mSignalLeapFocusGained; }
+    //! Returns onFocusLost signal for use in connecting user defined callbacks
+    EventSignalLeap&     getSignalLeapFocusLost() { return mListener.mSignalLeapFocusLost; }
+    //! Returns onInit signal for use in connecting user defined callbacks
+    EventSignalLeap&     getSignalLeapInit() { return mListener.mSignalLeapInit; }
 
 	//! Returns true if app is focused for this device.
 	bool				hasFocus() const;


### PR DESCRIPTION
This is implemented in the style of Cinder's mouse and keyboard events, and the Cinder ListenerBasic sample. 

To allow MyClass to listen to the Leap's onConnect event, for example, one would:
1. Add a private member variable of type `ci::signals::scoped_connection` to hold the connection
2. Pass in a `LeapSdk::DeviceRef` to the constructor
3. Connect a function to the signal

``` cpp
MyClass::MyClass( LeapSdk::DeviceRef aDevice )
{
    mCbLeapConnect = aDevice->getSignalLeapConnect().connect( std::bind( &MyClass::onLeapConnect, this ) );
}
```

Then when `LeapSdk::Listener::onConnect` is called, any other functions that have connected to this signal will also be called.

What do you think of this? Is it a sensible way to allow multiple classes to respond to onConnect and related Leap signals without them having to poll `LeapSdk::Device::isConnected` etc?

Also, there was a small typo in line 92 (sorry, should have done that as a separate commit).
